### PR TITLE
Fix clone stability

### DIFF
--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -195,7 +195,7 @@ class BaseRepo:
         if "GIT_SSH_COMMAND" in os.environ:
             previous_git_ssh_command = os.environ["GIT_SSH_COMMAND"]
 
-        # os.environ["GIT_TERMINAL_PROMPT"] = "0"
+        os.environ["GIT_TERMINAL_PROMPT"] = "0"
         os.environ["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=yes"
 
         print("Cloning", url)

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -194,7 +194,7 @@ class BaseRepo:
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)
         except git.exc.GitCommandError as e:
-            print(f"Clone from {url} failed. Trying clone from {ssh_url_to_http_url(url)} with {e}")
+            print(f"Clone from {url} failed. Trying clone from {ssh_url_to_http_url(url)} with {e, e.stderr, e.stdout}")
             try:
                 git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
             except Exception as e_inner:

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -195,8 +195,10 @@ class BaseRepo:
         if "GIT_SSH_COMMAND" in os.environ:
             previous_git_ssh_command = os.environ["GIT_SSH_COMMAND"]
 
-        os.environ["GIT_TERMINAL_PROMPT"] = "0"
+        # os.environ["GIT_TERMINAL_PROMPT"] = "0"
         os.environ["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=yes"
+
+        print("Cloning", url)
 
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -187,40 +187,46 @@ class BaseRepo:
     @classmethod
     def clone_from(cls, url, to_path, multi_options: Optional[List[str]] = None, **kwargs):
         # prevent git terminal prompts from interrupting the process.
-        previous_git_terminal_prompt = None
-        if "GIT_TERMINAL_PROMPT" in os.environ:
-            previous_git_terminal_prompt = os.environ["GIT_TERMINAL_PROMPT"]
-
-        previous_git_ssh_command = None
-        if "GIT_SSH_COMMAND" in os.environ:
-            previous_git_ssh_command = os.environ["GIT_SSH_COMMAND"]
-
-        os.environ["GIT_TERMINAL_PROMPT"] = "0"
-        os.environ["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=yes"
+        previous_git_ssh_command, previous_git_terminal_prompt = cls.git_environ_setup()
 
         print("Cloning", url)
 
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)
         except git.exc.GitCommandError as e:
-            print(f"Clone from {url} failed. Trying clone from {ssh_url_to_http_url(url)}")
-            traceback.print_exc()
+            print(f"Clone from {url} failed. Trying clone from {ssh_url_to_http_url(url)} with {e}")
             try:
                 git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
             except Exception as e_inner:
                 raise e_inner
         finally:
-            if previous_git_terminal_prompt is None:
-                os.environ.pop("GIT_TERMINAL_PROMPT")
-            else:
-                os.environ["GIT_TERMINAL_PROMPT"] = previous_git_terminal_prompt
-            if previous_git_ssh_command is None:
-                os.environ.pop("GIT_SSH_COMMAND")
-            else:
-                os.environ["GIT_SSH_COMMAND"] = previous_git_ssh_command
+            cls.git_environ_reset(previous_git_ssh_command, previous_git_terminal_prompt)
 
         instance = cls(to_path)
         return instance
+
+    @classmethod
+    def git_environ_setup(cls):
+        previous_git_terminal_prompt = None
+        if "GIT_TERMINAL_PROMPT" in os.environ:
+            previous_git_terminal_prompt = os.environ["GIT_TERMINAL_PROMPT"]
+        previous_git_ssh_command = None
+        if "GIT_SSH_COMMAND" in os.environ:
+            previous_git_ssh_command = os.environ["GIT_SSH_COMMAND"]
+        os.environ["GIT_TERMINAL_PROMPT"] = "0"
+        os.environ["GIT_SSH_COMMAND"] = "ssh -o StrictHostKeyChecking=yes"
+        return previous_git_ssh_command, previous_git_terminal_prompt
+
+    @classmethod
+    def git_environ_reset(cls, previous_git_ssh_command, previous_git_terminal_prompt):
+        if previous_git_terminal_prompt is None:
+            os.environ.pop("GIT_TERMINAL_PROMPT")
+        else:
+            os.environ["GIT_TERMINAL_PROMPT"] = previous_git_terminal_prompt
+        if previous_git_ssh_command is None:
+            os.environ.pop("GIT_SSH_COMMAND")
+        else:
+            os.environ["GIT_SSH_COMMAND"] = previous_git_ssh_command
 
     def add_remote(self, remote_url, remote_name=None):
         """

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -192,6 +192,8 @@ class BaseRepo:
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)
         except git.exc.GitCommandError as e:
+            print(f"Clone from {url} failed. Trying clone from {ssh_url_to_http_url(url)}")
+            traceback.print_exc()
             try:
                 git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
             except Exception as e_inner:

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -192,11 +192,12 @@ class BaseRepo:
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)
         except git.exc.GitCommandError as e:
+            print(f"Clone from {url} failed with {e, e.stderr, e.stdout}.")
+            print(f"Retrying with {ssh_url_to_http_url(url)}.")
             try:
                 git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
             except Exception as e_inner:
-                print(f"Clone from {url} failed with {e, e.stderr, e.stdout}")
-                print(f"and clone from {ssh_url_to_http_url(url)} failed with: ")
+                print(f"Clone from {ssh_url_to_http_url(url)} failed with: ")
                 raise e_inner
         finally:
             cls._git_environ_reset(previous_environment_variables)

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -192,11 +192,10 @@ class BaseRepo:
         try:
             git.Repo.clone_from(url, to_path, multi_options=multi_options, **kwargs)
         except git.exc.GitCommandError as e:
-            if "Host key verification failed." in e.stderr or "Permission denied (publickey)" in e.stderr:
-                try:
-                    git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
-                except Exception as e_inner:
-                    raise e_inner
+            try:
+                git.Repo.clone_from(ssh_url_to_http_url(url), to_path, multi_options=multi_options, **kwargs)
+            except Exception as e_inner:
+                raise e_inner
             else:
                 raise e
         instance = cls(to_path)

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -200,8 +200,6 @@ class BaseRepo:
                 print(f"Clone from {url} failed with {e, e.stderr, e.stdout}")
                 print(f"and clone from {ssh_url_to_http_url(url)} failed with: ")
                 raise e_inner
-            finally:
-                cls._git_environ_reset(previous_environment_variables)
         finally:
             cls._git_environ_reset(previous_environment_variables)
 

--- a/tests/test_git_adapter.py
+++ b/tests/test_git_adapter.py
@@ -277,23 +277,23 @@ def test_error_stack():
 def test_cadet_rdm(path_to_repo):
     # because these depend on one-another and there is no native support afaik for sequential tests
     # these tests are called sequentially here as try_ functions.
-    try_initialize_git_repo(path_to_repo)
+    # try_initialize_git_repo(path_to_repo)
     try_initialize_from_remote()
 
-    try_add_remote(path_to_repo)
-    # try_add_submodule(path_to_repo)
-    try_commit_code(path_to_repo)
-    try_commit_code_without_code_changes(path_to_repo)
-    try_commit_results_with_uncommitted_code_changes(path_to_repo)
-    try_output_function(path_to_repo)
-
-    try_commit_results_with_options(path_to_repo)
-    results_branch_name = try_commit_results_data(path_to_repo)
-    try_print_log(path_to_repo)
-
-    try_commit_code(path_to_repo)
-
-    try_load_previous_output(path_to_repo, results_branch_name)
+    # try_add_remote(path_to_repo)
+    # # try_add_submodule(path_to_repo)
+    # try_commit_code(path_to_repo)
+    # try_commit_code_without_code_changes(path_to_repo)
+    # try_commit_results_with_uncommitted_code_changes(path_to_repo)
+    # try_output_function(path_to_repo)
+    #
+    # try_commit_results_with_options(path_to_repo)
+    # results_branch_name = try_commit_results_data(path_to_repo)
+    # try_print_log(path_to_repo)
+    #
+    # try_commit_code(path_to_repo)
+    #
+    # try_load_previous_output(path_to_repo, results_branch_name)
 
 
 def test_with_detached_head():

--- a/tests/test_git_adapter.py
+++ b/tests/test_git_adapter.py
@@ -277,23 +277,23 @@ def test_error_stack():
 def test_cadet_rdm(path_to_repo):
     # because these depend on one-another and there is no native support afaik for sequential tests
     # these tests are called sequentially here as try_ functions.
-    # try_initialize_git_repo(path_to_repo)
+    try_initialize_git_repo(path_to_repo)
     try_initialize_from_remote()
 
-    # try_add_remote(path_to_repo)
-    # # try_add_submodule(path_to_repo)
-    # try_commit_code(path_to_repo)
-    # try_commit_code_without_code_changes(path_to_repo)
-    # try_commit_results_with_uncommitted_code_changes(path_to_repo)
-    # try_output_function(path_to_repo)
-    #
-    # try_commit_results_with_options(path_to_repo)
-    # results_branch_name = try_commit_results_data(path_to_repo)
-    # try_print_log(path_to_repo)
-    #
-    # try_commit_code(path_to_repo)
-    #
-    # try_load_previous_output(path_to_repo, results_branch_name)
+    try_add_remote(path_to_repo)
+    # try_add_submodule(path_to_repo)
+    try_commit_code(path_to_repo)
+    try_commit_code_without_code_changes(path_to_repo)
+    try_commit_results_with_uncommitted_code_changes(path_to_repo)
+    try_output_function(path_to_repo)
+
+    try_commit_results_with_options(path_to_repo)
+    results_branch_name = try_commit_results_data(path_to_repo)
+    try_print_log(path_to_repo)
+
+    try_commit_code(path_to_repo)
+
+    try_load_previous_output(path_to_repo, results_branch_name)
 
 
 def test_with_detached_head():


### PR DESCRIPTION
This PR improves the stability of cloning projects, especially in headless situations such as during CI or in containerized applications.

These include setting the environment variables `"GIT_TERMINAL_PROMPT": "0",`  and `"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=yes",` to ensure that ssh checkouts are refused if the host is not know without an additional prompt.

Also setting the environment variable `"GIT_CLONE_PROTECTION_ACTIVE": "0",` to fix https://github.com/git-lfs/git-lfs/issues/5749 for systems with outdated `git` installations.