### PR TITLE
Use git archive to copy output data to cache

### DIFF
--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1338,18 +1338,19 @@ class ProjectRepo(BaseRepo):
             branch_name = self.output_repo._git_repo.active_branch.name
 
         # Define the target folder
-        target_folder = self.path / f"{self._output_folder}_cached" / branch_name
+        target_folder = self.path / f"{self._output_folder}_cached" / str(branch_name)
 
         # Create the target folder if it doesn't exist
         if not target_folder.exists():
             target_folder.mkdir(parents=True, exist_ok=True)
 
             # Create a temporary file for the archive and perform extraction
-            with tempfile.NamedTemporaryFile() as temp_archive:
+            with tempfile.NamedTemporaryFile(suffix=".tar", delete_on_close=False) as temp_archive:
                 # Create an archive of the specified branch
                 self.output_repo._git_repo.git.archive(
                     branch_name, output=temp_archive.name
                 )
+                temp_archive.close()
 
                 # Open the temporary file in read mode
                 with open(temp_archive.name, 'rb') as archive_file:
@@ -1410,9 +1411,9 @@ class ProjectRepo(BaseRepo):
                 delete_path(main_cach_path)
             self.copy_data_to_cache(self._output_repo.main_branch)
             # print("\n" + commit_return + "\n")
-        except git.exc.GitCommandError as e:
-            self.output_repo.delete_active_branch_if_branch_is_empty()
-            raise e
+        # except git.exc.GitCommandError as e:
+        #     self.output_repo.delete_active_branch_if_branch_is_empty()
+        #     raise e
         finally:
             # self.remove_cached_files()
             self._is_in_context_manager = False

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1412,7 +1412,6 @@ class ProjectRepo(BaseRepo):
             if main_cach_path.exists():
                 delete_path(main_cach_path)
             self.copy_data_to_cache(self._output_repo.main_branch)
-            # print("\n" + commit_return + "\n")
         except git.exc.GitCommandError as e:
             self.output_repo.delete_active_branch_if_branch_is_empty()
             raise e

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1338,7 +1338,7 @@ class ProjectRepo(BaseRepo):
             branch_name = self.output_repo._git_repo.active_branch.name
 
         # Define the target folder
-        target_folder = self.path / "output_cached" / branch_name
+        target_folder = self.path / f"{self._output_folder}_cached" / branch_name
 
         # Create the target folder if it doesn't exist
         if not target_folder.exists():

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1102,7 +1102,7 @@ class ProjectRepo(BaseRepo):
 
         self.dump_package_list(logs_folderpath)
 
-        self.copy_code(logs_folderpath)
+        self._copy_code(logs_folderpath)
 
         self._output_repo.add(".")
         self._output_repo._git.commit("-m", f"log for '{output_commit_message}' \n"
@@ -1111,7 +1111,7 @@ class ProjectRepo(BaseRepo):
         self._output_repo._git.checkout(output_branch_name)
         self._most_recent_branch = output_branch_name
 
-    def copy_code(self, target_path):
+    def _copy_code(self, target_path):
         """
         Clone only the current branch of the project repo to the target_path
         and then compress it into a zip file.
@@ -1122,15 +1122,11 @@ class ProjectRepo(BaseRepo):
         if type(target_path) is str:
             target_path = Path(target_path)
 
-        code_tmp_folder = target_path / "git_repo"
+        code_tmp_folder = target_path / "code.tar"
 
-        multi_options = ["--filter=blob:none", "--single-branch"]
-        git.Repo.clone_from(self.path, code_tmp_folder, multi_options=multi_options)
-
-        delete_path(code_tmp_folder / ".git")
-        shutil.make_archive(target_path / "code", "zip", code_tmp_folder)
-
-        delete_path(code_tmp_folder)
+        self._git_repo.git.archive(
+            self.active_branch, output=code_tmp_folder
+        )
 
     def commit(self, message: str | None = None, add_all=True, verbosity=1):
         """

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1413,9 +1413,9 @@ class ProjectRepo(BaseRepo):
                 delete_path(main_cach_path)
             self.copy_data_to_cache(self._output_repo.main_branch)
             # print("\n" + commit_return + "\n")
-        # except git.exc.GitCommandError as e:
-        #     self.output_repo.delete_active_branch_if_branch_is_empty()
-        #     raise e
+        except git.exc.GitCommandError as e:
+            self.output_repo.delete_active_branch_if_branch_is_empty()
+            raise e
         finally:
             # self.remove_cached_files()
             self._is_in_context_manager = False


### PR DESCRIPTION
By using archive, we can avoid having to checkout the output branch which can lead to an inconsistent state during execution.