### PR TITLE
Add dependency groups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -U pytest setuptools
-          pip install .[testing]
+          pip install . --group testing
 
       - name: Verify Installation
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ documentation = "https://cadet-rdm.readthedocs.io/en/latest/index.html"
 "Bug Tracker" = "https://github.com/cadet/CADET-RDM/issues"
 
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = [
     "setuptools",
     "pytest",
@@ -57,14 +57,6 @@ testing = [
     "numpy",
     "build",
 ]
-jupyter = [
-    "nbformat",
-    "nbconvert",
-    "ipylab",
-    "junix",
-    "jupytext",
-    "jupyterlab",
-]
 docs = [
     "sphinx>=5.3.0",
     "sphinxcontrib-bibtex>=2.5.0",
@@ -73,6 +65,16 @@ docs = [
     "sphinx-sitemap>=2.5.0",
     "numpydoc>=1.5.0",
     "myst-nb>=0.17.1",
+]
+
+[project.optional-dependencies]
+jupyter = [
+    "nbformat",
+    "nbconvert",
+    "ipylab",
+    "junix",
+    "jupytext",
+    "jupyterlab",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Adding the dependency group feature as statet in [Dependency Groups](https://packaging.python.org/en/latest/specifications/dependency-groups/). Optional Dependencies should actually add some additional, optional features for the user. 
For development or testing environment, we can define dependency groups and install them with ```pip install . --group testing```.


I guess jupyter is an optional dependency ?