### PR TITLE
Add ruff linter

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Ruff
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check --output-format=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+
+# pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+# ruff
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.11.7
+  hooks:
+    # Run the linter.
+    - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ docs = [
     "numpydoc>=1.5.0",
     "myst-nb>=0.17.1",
 ]
+dev = [
+    {include-group = "docs"},
+    {include-group = "testing"},
+    "pre-commit",
+    "ruff<=0.11.4",
+]
 
 [project.optional-dependencies]
 jupyter = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,29 @@ jupyter = [
     "jupyterlab",
 ]
 
+[tool.ruff]
+src = ["cadetrdm", "tests"]
+exclude = ["examples", "docs"]
+line-length = 88
+
+[tool.ruff.lint]
+preview = true
+select = ["E", "F", "W", "D", "ANN"]
+ignore = ["D100", "D212", "D203", "ANN401"]
+exclude = ['__init__.py']
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 100
+max-doc-length = 94
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["D", "E731", "ANN", "E402"]
+# E731 are lambda expressions for tests, D are general docstrings
+
+
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",


### PR DESCRIPTION
Added the basic configuration for CADET-RDM similar to [Process](https://github.com/fau-advanced-separations/CADET-Process/pull/259).

Also added a dev dependency group that additionaly installs ruff, docs and testing. 

Summary of the linting rules:
I decided for following linting [rules](https://docs.astral.sh/ruff/rules/):
E, F, W, D, ANN

E and W are typical PycodeStyle rules like using tab and or mixed with withespace, whitespaces between operator and so on.

F are pyflake rules, checking for imports, f strings, unused imports and so on.

D are a set of docstring rules. Docstrings will be enforced for all public classes functions and methods and packages with the only exeption beeing modules. Excluded are D100, D212, D203. We enforce an descriptive imperative sentence at the start of every docstring. Module docstring are excluded because there are problems with sphinx used docstrings that do not fit the standard rules. So you need to exclude the docstring from ruff checking by using #noqa. 

ANN is enforced type checking for pretty much any public and private function and method. Rules ANN401 is excluded because there are many cases where Type Any is more convenient to use. Maybe we can inlude this one at a later time.

For all test Files the Docstring and Annotation Rules are disabled. as well as E731 and E402 (module import not at top and some lambda assignments).



As for now the ruff pipeline should fail but not block even when creating an error. If you use pre-commit you won't be able to push if the ruff checks fail so until the linting rules are satisfied as far as i understand. So the github action to check linting is there to check wheter the developer actualy uses pre commit :D