### PR TITLE
Fix name and trigger in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-name: Build and Publish cadet-rdm
+name: Build and Publish CADET-RDM
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This updates the name and the trigger in the release workflow to only run on GitHub releases.