### PR TITLE
Modify README.md at Example initialization to match README template with cookiecutter

### DIFF
--- a/cadetrdm/initialize_repo.py
+++ b/cadetrdm/initialize_repo.py
@@ -241,7 +241,12 @@ def create_readme():
 
 
 def create_output_readme():
-    readme_lines = ["## Project Repository",
+    readme_lines = ["# Output repository for Example Simulation with CADET",
+                    "This repository stores the simulation results for RDM-Example. `CADET-RDM` automatically tracks all simulations that are started by running `main.py` from the corresponding project repository.",
+                    "",
+                    "Each simulation run creates a dedicated branch in this output repository. The results are saved within the `src` folder of the respective branch. Additionally, a `log.tsv` file in the main branch records metadata for all runs, uniquely linking each output branch to its originating run in the project repository.",
+                    "",
+                    "## Project Repository",
                     "",
                     "The project repository for this case study is available here:",
                     "[Link to Project Repository]() (not actually set yet because no remote has been configured at this moment)"]

--- a/cadetrdm/initialize_repo.py
+++ b/cadetrdm/initialize_repo.py
@@ -233,22 +233,20 @@ def create_environment_yml():
 
 
 def create_readme():
-    readme_lines = ["# Project repo", "Your code goes in this repo.", "Please add a description here including: ",
-                    "- authors", "- project", "- things we will find interesting later", "", "",
-                    "Please update the environment.yml with your python environment requirements.", "", "",
-                    "The output repository can be found at:",
-                    "[output_repo]() (not actually set yet because no remote has been configured at this moment"]
+    readme_lines = ["## Output Repository", 
+                    "",
+                    "The output data for this case study can be found here:",
+                    "[Link to Output Repository]() (not actually set yet because no remote has been configured at this moment)"]
     write_lines_to_file("README.md", readme_lines, open_type="a")
 
 
 def create_output_readme():
-    readme_lines = ["# Output repo", "Your results will be stored here.", "Please add a description here including: ",
-                    "- authors", "- project", "- things we will find interesting later", "", "",
-                    "The project repository can be found at:",
-                    "[project_repo]() (not actually set yet because no remote has been configured at this moment"]
+    readme_lines = ["## Project Repository",
+                    "",
+                    "The project repository for this case study is available here:",
+                    "[Link to Project Repository]() (not actually set yet because no remote has been configured at this moment)"]
     write_lines_to_file("README.md", readme_lines, open_type="a")
 
 
 def create_dockerfile():
     write_lines_to_file("Dockerfile", dockerfile_template, open_type="w")
-

--- a/cadetrdm/initialize_repo.py
+++ b/cadetrdm/initialize_repo.py
@@ -248,7 +248,7 @@ def create_output_readme():
                     "",
                     "## Project Repository",
                     "",
-                    "The project repository for this case study is available here:",
+                    "The project repository for this case study is available here: ",
                     "[Link to Project Repository]() (not actually set yet because no remote has been configured at this moment)"]
     write_lines_to_file("README.md", readme_lines, open_type="a")
 

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -562,14 +562,14 @@ class BaseRepo(GitRepo):
                 if output_repo.has_uncomitted_changes:
                     output_repo.stash_all_changes()
                 output_repo.checkout(output_repo.main_branch)
-            output_repo.add_list_of_remotes_in_readme_file("project_repo", self.remote_urls)
+            output_repo.add_list_of_remotes_in_readme_file("Link to Project Repository", self.remote_urls)
             output_repo.add("README.md")
             output_repo.commit("Add remote for project repo", verbosity=0, add_all=False)
         if self._metadata["is_output_repo"]:
             # This folder is an output repo
             project_repo = ProjectRepo(self.path.parent)
             project_repo.update_output_remotes_json()
-            project_repo.add_list_of_remotes_in_readme_file("output_repo", self.remote_urls)
+            project_repo.add_list_of_remotes_in_readme_file("Link to Output Repository", self.remote_urls)
             project_repo.add(project_repo.data_json_path)
             project_repo.add("README.md")
             project_repo.commit("Add remote for output repo", verbosity=0, add_all=False)
@@ -745,7 +745,7 @@ class BaseRepo(GitRepo):
                     line_to_be_modified = filelines_giving_output_repo[0]
                     filelines[line_to_be_modified] = output_link_line
                 elif len(filelines_giving_output_repo) == 0:
-                    filelines.append("The output repo can be found at:\n")
+                    filelines.append("The output repository can be found at:\n") #method can be used for project and output repositories, "the corresponding repository can be found at... would be better"
                     filelines.append(output_link_line)
                 else:
                     raise RuntimeError(f"Multiple lines in the README.md at {readme_filepath}"
@@ -1157,13 +1157,13 @@ class ProjectRepo(BaseRepo):
 
         # update urls in main branch of output_repo
         self.output_repo._git.checkout(self.output_repo.main_branch)
-        self.output_repo.add_list_of_remotes_in_readme_file("project_repo", self.remote_urls)
+        self.output_repo.add_list_of_remotes_in_readme_file("Link to Project Repository", self.remote_urls)
         if commit:
             self.output_repo.commit(message="Update remote links", add_all=False, verbosity=1)
 
     def update_output_remotes_json(self):
         output_repo_remotes = self.output_repo.remote_urls
-        self.add_list_of_remotes_in_readme_file("output_repo", output_repo_remotes)
+        self.add_list_of_remotes_in_readme_file("Link to Output Repository", output_repo_remotes)
 
         with open(self.data_json_path, "r") as file_handle:
             metadata = json.load(file_handle)
@@ -1297,7 +1297,7 @@ class ProjectRepo(BaseRepo):
         # update urls in main branch of output_repo
         output_repo._git.checkout(output_repo.main_branch)
         project_repo_remotes = self.remote_urls
-        output_repo.add_list_of_remotes_in_readme_file("project_repo", project_repo_remotes)
+        output_repo.add_list_of_remotes_in_readme_file("Link to Project Repository", project_repo_remotes)
         output_repo.commit("Update urls", verbosity=0)
 
         # Create the new branch

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -737,7 +737,7 @@ class BaseRepo(GitRepo):
                                             for output_repo_remote in remotes_url_list_http) + "\n"
 
             readme_filepath = self.path / "README.md"
-            with open(readme_filepath, "r") as file_handle:
+            with open(readme_filepath, "r", encoding="utf-8") as file_handle:
                 filelines = file_handle.readlines()
                 filelines_giving_output_repo = [i for i in range(len(filelines))
                                                 if filelines[i].strip().startswith(f"[{repo_identifier}](")]

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -740,7 +740,7 @@ class BaseRepo(GitRepo):
             with open(readme_filepath, "r") as file_handle:
                 filelines = file_handle.readlines()
                 filelines_giving_output_repo = [i for i in range(len(filelines))
-                                                if filelines[i].startswith(f"[{repo_identifier}](")]
+                                                if filelines[i].strip().startswith(f"[{repo_identifier}](")]
                 if len(filelines_giving_output_repo) == 1:
                     line_to_be_modified = filelines_giving_output_repo[0]
                     filelines[line_to_be_modified] = output_link_line

--- a/tests/test_git_adapter.py
+++ b/tests/test_git_adapter.py
@@ -277,10 +277,10 @@ def test_rdm_check():
     repo.check()
     with open(repo.path / "README.md", "r") as handle:
         readme_lines = handle.readlines()
-    assert f'[output_repo]({ssh_url_to_http_url(new_output_url)})\n' in readme_lines
+    assert f'[Link to Output Repository]({ssh_url_to_http_url(new_output_url)})\n' in readme_lines
     with open(repo.output_repo.path / "README.md", "r") as handle:
         readme_lines = handle.readlines()
-    assert f'[project_repo]({ssh_url_to_http_url(new_project_url)})\n' in readme_lines
+    assert f'[Link to Project Repository]({ssh_url_to_http_url(new_project_url)})\n' in readme_lines
 
 
 def test_copy_external_data():


### PR DESCRIPTION
The README.md text is modified to match the Example README template in correspondence with the [cookiecutter templete](https://github.com/cadet/RDM-Cookiecutter-Example-Template.git) for the easy set up of RDM-Examples. 

<img width="807" height="1042" alt="grafik" src="https://github.com/user-attachments/assets/da676c0e-7754-4ec3-9ff6-1b3ea91d5210" />


The automatic recognition of the remote repository names for insertion into the README files is set up by the "repo_identifier" parameter of the "add_list_of_remotes_in_readme_file" method in the BaseRepo class (cadetrdm\repositories.py). The arguments for the "repo_identifier"s, taken from cadetrdm\initialize_repo.py, are now "Link to Output/ProjectRepository", not "output/project_repo".


