### PR TITLE
Exclude branch_prefix from options hash

### DIFF
--- a/cadetrdm/options.py
+++ b/cadetrdm/options.py
@@ -86,7 +86,7 @@ class Options(Dict):
         return cls.loads(string)
 
     def get_hash(self):
-        excluded_keys = {"commit_message", "push", "debug", "force"}
+        excluded_keys = {"branch_prefix", "commit_message", "push", "debug", "force"}
         remaining_dict = remove_invalid_keys(self, excluded_keys=excluded_keys)
         dump = json.dumps(
             remaining_dict,

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -948,12 +948,11 @@ class ProjectRepo(BaseRepo):
         project_repo_hash = str(self.head.commit)
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
-        if self.options and "branch_prefix" in self.options:
-            branch_prefix = self.options["branch_prefix"]+"_"
-        else:
-            branch_prefix = ""
+        branch_name = f"{timestamp}_{self.active_branch}_{project_repo_hash[:7]}"
 
-        branch_name = branch_prefix+"_".join([timestamp, str(self.active_branch), project_repo_hash[:7]])
+        if self.options and "branch_prefix" in self.options:
+            branch_name = f"{self.options['branch_prefix']}_{branch_name}"
+
         return branch_name
 
     def check_results_main(self):


### PR DESCRIPTION
Since this does not affect the results, I added the `branch_prefex` to the keys being excluded when calculating the options hash (similar to `commit_message`).