### PR TITLE
Add options.json to log directory

### DIFF
--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1101,7 +1101,7 @@ class ProjectRepo(BaseRepo):
 
         self.output_repo._git.checkout(self.output_repo.main_branch)
 
-        logs_dir= self.output_repo.path / "run_history" / output_branch_name
+        logs_dir = self.output_repo.path / "run_history" / output_branch_name
         if not logs_dir.exists():
             os.makedirs(logs_dir)
 


### PR DESCRIPTION
This PR adds a json dump of the Options to the log directory. This way, we can inspect all options from the main branch which can help with evaluating / filtering / ... all of the previously run cases.

Fixes #98 