### PR TITLE
Fixes _add_branch_name_to_log

### DIFF
--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1768,20 +1768,29 @@ class OutputRepo(BaseRepo):
         """
         Update the TSV file by adding a 'project_repo_branch' column.
 
-        The branch name is extracted from the 'output_repo_commit_message' field.
+        The branch name is extracted from the 'Output repo branch' field.
         """
         self.checkout(self.main_branch)
 
         with open(self.output_log_file_path, "r") as f:
             reader = csv.DictReader(f, delimiter="\t")
             rows = list(reader)
+
+        if not rows:
+            return
+
         fieldnames = list(rows[0].keys())
+
+        # support old/new header names
+        if "output_repo_branch" in rows[0]:
+            branch_col = "output_repo_branch"
+        elif "Output repo branch" in rows[0]:
+            branch_col = "Output repo branch"
 
         # Add new column to header if not present
         if "project_repo_branch" not in rows[0]:
             for row in rows:
-                commit_msg = row["output_repo_branch"]
-                branch = commit_msg.split("_")[2]
+                branch = branch_colc.split("_")[2]
                 row["project_repo_branch"] = branch
 
         if "project_repo_branch" not in fieldnames:


### PR DESCRIPTION
When trying to update the Old examples, the method that adds the row "project repo branch" couldn't find the "output repo branch" to read from.

I have updated the function that adds the new column to the log tsv to allow checking "output repo branch" (not only "output_repo_branch") which includes the project repo branch and have removed ambiguity with the commit message field from the function documentation.