### PR TITLE
Update output repository before loading results

### DIFF
--- a/cadetrdm/batch_running/case.py
+++ b/cadetrdm/batch_running/case.py
@@ -294,6 +294,7 @@ class Case:
         Returns:
             Path to results.
         """
+        self.output_repo.update()
         results_branch = self._get_results_branch(
             allow_commit_hash_mismatch=allow_commit_hash_mismatch,
             allow_options_hash_mismatch=allow_options_hash_mismatch,


### PR DESCRIPTION
This PR adds a call to `output_repo.update()` so that we always consider the latest results when loading from cache.

We could also make this optional via an argument, what do you think @hannahlanzrath?

Note, this builds upon #112