### PR TITLE
Expose git add to CLI and remove add_all= True as default from repo.commit()

### DIFF
--- a/cadetrdm/cli_integration.py
+++ b/cadetrdm/cli_integration.py
@@ -90,6 +90,14 @@ def commit(message, all):
     del repo
 
 
+@cli.command(help="Stage changes")
+@click.argument("filepath", type=click.Path())
+def add(filepath):
+    from cadetrdm.repositories import ProjectRepo
+    repo = ProjectRepo(".")
+    repo.add(filepath)
+
+
 @cli.group(help="Execute commands and track the results.")
 def run():
     pass

--- a/cadetrdm/initialize_repo.py
+++ b/cadetrdm/initialize_repo.py
@@ -224,7 +224,7 @@ def initialize_output_repo(output_directory_name, gitignore: list = None,
     create_output_readme()
 
     repo = OutputRepo(".")
-    repo.commit("initial commit")
+    repo.commit("initial commit", add_all=True)
 
     os.chdir(starting_directory)
 

--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -300,7 +300,7 @@ class GitRepo:
     def commit(
         self,
         message: str | None = None,
-        add_all=True,
+        add_all=False,
         verbosity=1,
     ) -> None:
         """
@@ -593,7 +593,7 @@ class BaseRepo(GitRepo):
                 output_repo.checkout(output_repo.main_branch)
             output_repo.add_list_of_remotes_in_readme_file("Link to Project Repository", self.remote_urls)
             output_repo.add("README.md")
-            output_repo.commit("Add remote for project repo", verbosity=0, add_all=False)
+            output_repo.commit("Add remote for project repo", verbosity=0)
         if self.metadata["is_output_repo"]:
             # This directory is an output repository.
             project_repo = ProjectRepo(self.path.parent)
@@ -601,7 +601,7 @@ class BaseRepo(GitRepo):
             project_repo.add_list_of_remotes_in_readme_file("Link to Output Repository", self.remote_urls)
             project_repo.add(project_repo.data_json_path)
             project_repo.add("README.md")
-            project_repo.commit("Add remote for output repo", verbosity=0, add_all=False)
+            project_repo.commit("Add remote for output repo", verbosity=0)
 
     def import_remote_repo(self, source_repo_location, source_repo_branch, target_repo_location=None):
         """
@@ -1177,13 +1177,13 @@ class ProjectRepo(BaseRepo):
         """
         self.update_output_remotes_json()
         if commit:
-            super().commit(message="Update remote links", add_all=False, verbosity=1)
+            super().commit(message="Update remote links", verbosity=1)
 
         # update urls in main branch of output_repo
         self.output_repo._git.checkout(self.output_repo.main_branch)
         self.output_repo.add_list_of_remotes_in_readme_file("Link to Project Repository", self.remote_urls)
         if commit:
-            self.output_repo.commit(message="Update remote links", add_all=False, verbosity=1)
+            self.output_repo.commit(message="Update remote links", verbosity=1)
 
     def update_output_remotes_json(self, load_metadata=True):
         output_repo_remotes = self.output_repo.remote_urls
@@ -1724,7 +1724,7 @@ class OutputRepo(BaseRepo):
         )
         self.add(self.path / "log.csv")
         self.add(self.path / "log.tsv")
-        self.commit("Convert csv to tsv", add_all=False)
+        self.commit("Convert csv to tsv")
 
     def _expand_tsv_header(self):
         """Update tsv header."""
@@ -1750,7 +1750,7 @@ class OutputRepo(BaseRepo):
             f.writelines(lines[1:])
 
         self.add(self.output_log_file_path)
-        self.commit("Update tsv header", add_all=False)
+        self.commit("Update tsv header")
 
     def _update_headers(self):
         """Update tsv header."""
@@ -1776,7 +1776,7 @@ class OutputRepo(BaseRepo):
             f.writelines(lines[1:])
 
         self.add(self.output_log_file_path)
-        self.commit("Update tsv header", add_all=False)
+        self.commit("Update tsv header")
 
     def _fix_gitattributes_log_tsv(self):
         """Update .gitattributes to account for changed logfile name."""
@@ -1788,7 +1788,7 @@ class OutputRepo(BaseRepo):
             handle.writelines(lines)
 
         self.add(".gitattributes")
-        self.commit("Update .gitattributes", add_all=False)
+        self.commit("Update .gitattributes")
 
     def _update_log_hashes(self):
         if self.has_uncomitted_changes:
@@ -1813,7 +1813,7 @@ class OutputRepo(BaseRepo):
             log.write()
 
         self.add(self.output_log_file_path)
-        self.commit(message="Updated log hashes", add_all=False)
+        self.commit(message="Updated log hashes")
 
     def _rename_project_repo_folder_to_directory_in_log(self) -> None:
         """Rename the TSV column header from folder to directory."""
@@ -1902,7 +1902,7 @@ class OutputRepo(BaseRepo):
 
 
 class JupyterInterfaceRepo(ProjectRepo):
-    def commit(self, message: str | None = None, add_all=True, verbosity=1):
+    def commit(self, message: str | None = None, add_all=False, verbosity=1):
         """
         Commit current state of the repository.
 

--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -52,16 +52,22 @@ The command must be enclosed in quotes.
 
 ### Staging, committing, and pushing changes
 
-Check repository consistency and stage changes:
+Check repository consistency:
 
 ```bash
 rdm check
 ```
 
-Commit staged changes:
+Stage changes:
 
 ```bash
-rdm commit -m <message>
+rdm add <filepath>
+```
+
+Commit staged changes (option: setting `-a` will stage all changes and commit them):
+
+```bash
+rdm commit -m <message> [-a]
 ```
 
 Push both project and output repositories:

--- a/docs/source/user_guide/python-interface.md
+++ b/docs/source/user_guide/python-interface.md
@@ -45,8 +45,12 @@ Results are tracked using the `ProjectRepo` interface. All files written inside 
 from cadetrdm import ProjectRepo
 
 repo = ProjectRepo()
+repo.add(path_to_changed_file)
 repo.commit("Commit code changes")
+```
+Optionally, the argument `add_all=True` can be given to `repo.commit()` to stage all changed files and commit them instead of using the preceding `repo.add()`.
 
+```python
 with repo.track_results(results_commit_message="Generate results"):
     data = generate_data()
     write_data_to_file(data, output_directory=repo.output_directory)


### PR DESCRIPTION
This PR seeks to harmonize CADET-RDM further with the Git Interface, by exposing `git add` via `rdm add`, giving the possibility to stage single files instead of adding all with the commit. Secondly, the default setting of `add_all=True` for the Python interface method `repo.commit()` is changed to `False`, and the arguments removed from internal function calls respectively. Finanlly, the documentation is updated to make the use of these commands clearer and reflect those changes.