### PR TITLE
Run repository-creating tests in temp dirs

### DIFF
--- a/tests/test_batch_runner.py
+++ b/tests/test_batch_runner.py
@@ -7,6 +7,11 @@ from cadetrdm import Options, Case, Environment, ProjectRepo, initialize_repo
 from cadetrdm.io_utils import delete_path
 
 
+@pytest.fixture(autouse=True)
+def isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.mark.server_api
 def test_module_import():
     WORK_DIR = Path.cwd() / "tmp"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,11 @@ from cadetrdm.io_utils import delete_path
 runner = CliRunner()
 
 
+@pytest.fixture(autouse=True)
+def isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 def create_repo():
     if os.path.exists("test_repo_cli"):
         delete_path("test_repo_cli")

--- a/tests/test_git_adapter.py
+++ b/tests/test_git_adapter.py
@@ -1,5 +1,5 @@
 import os
-import random
+import uuid
 from pathlib import Path
 
 import git
@@ -27,7 +27,7 @@ def path_to_repo():
 
 def modify_code(path_to_repo):
     # Add changes to the project code
-    random_number = random.randint(0, 265)
+    random_number = uuid.uuid4().int
     filepath = path_to_repo / f"print_random_number.py"
     with open(filepath, "w") as file:
         file.write(f"print({random_number})\n")

--- a/tests/test_git_adapter.py
+++ b/tests/test_git_adapter.py
@@ -14,6 +14,11 @@ from cadetrdm.web_utils import ssh_url_to_http_url
 from cadetrdm.wrapper import tracks_results
 
 
+@pytest.fixture(autouse=True)
+def isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture(scope="module")
 def path_to_repo():
     # a "fixture" serves up shared, ready variables to test functions that should use the fixture as a kwarg

--- a/tests/test_gitlab_api.py
+++ b/tests/test_gitlab_api.py
@@ -9,6 +9,11 @@ from cadetrdm.remote_integration import GitHubRemote, GitLabRemote
 from cadetrdm.repositories import BaseRepo
 
 
+@pytest.fixture(autouse=True)
+def isolated_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.mark.server_api
 def test_gitlab_create():
     url = "https://jugit.fz-juelich.de/"


### PR DESCRIPTION
Several tests create CADET-RDM repositories through relative paths such as `test_repo*` and `non_rdm_repo`. When those tests run from the repository root, the generated repositories are left behind as untracked files after the test run.

This adds module-local autouse fixtures that change the working directory to pytest's per-test `tmp_path` for the affected test modules. The tests can keep their existing relative-path setup, but the generated repositories now land in pytest-managed temporary directories instead of polluting the project checkout.

Tested with:
`pytest tests/test_git_adapter.py tests/test_cli.py tests/test_batch_runner.py -m 'not server_api and not container'`