### PR TITLE
Archive remote output branches without creating local heads

### DIFF
--- a/cadetrdm/repositories.py
+++ b/cadetrdm/repositories.py
@@ -1403,12 +1403,10 @@ class ProjectRepo(BaseRepo):
             target_folder = self.cache_folder_for_branch(branch_name)
         target_folder = Path(target_folder)
 
-        # Ensure that the branch is available locally. If it's only a remote branch, git.archive will fail.
+        archive_ref = branch_name
         local_branches = [head.name for head in self.output_repo._git_repo.heads]
         if branch_name not in local_branches:
-            self.output_repo._git_repo.create_head(
-                branch_name, f"origin/{branch_name}"
-            )
+            archive_ref = f"origin/{branch_name}"
 
         # Create the target directory if it doesn't exist
         if not target_folder.exists():
@@ -1419,7 +1417,7 @@ class ProjectRepo(BaseRepo):
             os.close(handle)
             # Create an archive of the specified branch
             self.output_repo._git_repo.git.archive(
-                branch_name, output=temp_archive_name
+                archive_ref, output=temp_archive_name
             )
 
             # Open the temporary file in read mode

--- a/tests/test_read_only_loading.py
+++ b/tests/test_read_only_loading.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from cadetrdm import ProjectRepo, initialize_repo
+from cadetrdm.io_utils import delete_path
 
 
 def git_state(repo):
@@ -97,3 +98,27 @@ def test_output_log_is_empty_when_no_results_are_recorded(tmp_path):
     repo = ProjectRepo(path_to_repo)
 
     assert repo.output_repo.output_log.n_entries == 0
+
+
+def test_copy_data_to_cache_uses_remote_ref_without_creating_local_branch(repo_with_results):
+    output_repo = repo_with_results.output_repo
+    result_branch = str(output_repo.active_branch)
+    result_commit = output_repo.current_commit_hash
+    cache_folder = repo_with_results.cache_folder_for_branch(result_branch)
+
+    delete_path(cache_folder)
+    output_repo.checkout(output_repo.main_branch)
+    output_repo._git_repo.git.update_ref(
+        f"refs/remotes/origin/{result_branch}",
+        result_commit,
+    )
+    output_repo._git_repo.delete_head(result_branch, force=True)
+
+    state_before = git_state(output_repo)
+    assert result_branch not in state_before["branches"]
+
+    cache_path = repo_with_results.copy_data_to_cache(result_branch)
+
+    assert (cache_path / "result.csv").read_text() == "1,2,3\n"
+    assert git_state(output_repo) == state_before
+    assert result_branch not in [head.name for head in output_repo._git_repo.heads]


### PR DESCRIPTION
`ProjectRepo.copy_data_to_cache(branch)` avoided checking out the output branch, but it still created a local branch when the requested result only existed as `origin/<branch>`. That meant loading cached data could still mutate local Git refs.

This PR changes the cache path to archive the remote ref directly. If branch exists locally, it still archives the local branch. If it does not exist locally, it archives `origin/<branch>` directly without creating a local head.

The regression test sets up a result branch that only exists as a remote-tracking ref, calls `copy_data_to_cache()`, and checks that the cached result is copied while the output repository state and local branch list stay unchanged.

This is not intended as a breaking change. It removes another unintended side effect from a read/cache operation. Code that relied on `copy_data_to_cache()` creating a local output branch would behave differently, but callers can create that branch explicitly if they need it.