### PR TITLE
Do not update project repo when loading results

### DIFF
--- a/cadetrdm/batch_running/case.py
+++ b/cadetrdm/batch_running/case.py
@@ -282,6 +282,7 @@ class Case:
         allow_commit_hash_mismatch: bool = False,
         allow_options_hash_mismatch: bool = False,
         allow_environment_mismatch: bool = False,
+        fetch: bool = False,
     ) -> Path | None:
         """
         Load results for the current case.
@@ -290,14 +291,13 @@ class Case:
             allow_commit_hash_mismatch: If True, allow loading results with mismatched study commit hash.
             allow_options_hash_mismatch: If True, allow loading results with mismatched options hash.
             allow_environment_mismatch: If True, allow loading results with mismatched environment.
+            fetch: If True, fetch output repository refs before looking for matching results.
 
         Returns:
             Path to results.
         """
-        if not self.options.debug:
-            self.project_repo.update()
-        else:
-            print("WARNING: Not updating the repositories while in debug mode.")
+        if fetch:
+            self.output_repo.fetch()
 
         results_branch = self._get_results_branch(
             allow_commit_hash_mismatch=allow_commit_hash_mismatch,

--- a/tests/test_read_only_loading.py
+++ b/tests/test_read_only_loading.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from cadetrdm import ProjectRepo, initialize_repo
+from cadetrdm import Case, Options, ProjectRepo, initialize_repo
 from cadetrdm.io_utils import delete_path
 
 
@@ -44,6 +44,25 @@ def repo_with_results(tmp_path):
     assert str(repo.output_repo.active_branch) != repo.output_repo.main_branch
 
     return repo
+
+
+@pytest.fixture
+def case_with_results(tmp_path):
+    path_to_repo = tmp_path / "project"
+    initialize_repo(path_to_repo, "results")
+
+    repo = ProjectRepo(path_to_repo)
+    options = Options({"case": "read-only-load"})
+    options.branch_prefix = "read-only-load"
+
+    with repo.track_results(results_commit_message="Add result", options=options):
+        (repo.output_path / "result.csv").write_text("1,2,3\n")
+
+    case = Case(project_repo=repo, options=options, name="read-only-load")
+    cache_folder = repo.cache_folder_for_branch(str(repo.output_repo.active_branch))
+    delete_path(cache_folder)
+
+    return case
 
 
 def test_reading_output_log_leaves_output_repo_untouched(repo_with_results):
@@ -122,3 +141,44 @@ def test_copy_data_to_cache_uses_remote_ref_without_creating_local_branch(repo_w
     assert (cache_path / "result.csv").read_text() == "1,2,3\n"
     assert git_state(output_repo) == state_before
     assert result_branch not in [head.name for head in output_repo._git_repo.heads]
+
+
+def test_case_load_does_not_update_project_repo(case_with_results, monkeypatch):
+    project_repo = case_with_results.project_repo
+    project_state_before = git_state(project_repo)
+    output_state_before = git_state(project_repo.output_repo)
+
+    def fail_update():
+        raise AssertionError("Case.load() updated the project repository")
+
+    def fail_fetch():
+        raise AssertionError("Case.load() fetched output repository refs by default")
+
+    monkeypatch.setattr(project_repo, "update", fail_update)
+    monkeypatch.setattr(project_repo.output_repo, "fetch", fail_fetch)
+
+    results_path = case_with_results.load()
+
+    assert (results_path / "result.csv").read_text() == "1,2,3\n"
+    assert git_state(project_repo) == project_state_before
+    assert git_state(project_repo.output_repo) == output_state_before
+
+
+def test_case_load_can_fetch_output_refs_explicitly(case_with_results, monkeypatch):
+    project_repo = case_with_results.project_repo
+    fetched = False
+
+    def fail_update():
+        raise AssertionError("Case.load() updated the project repository")
+
+    def fetch_output_refs():
+        nonlocal fetched
+        fetched = True
+
+    monkeypatch.setattr(project_repo, "update", fail_update)
+    monkeypatch.setattr(project_repo.output_repo, "fetch", fetch_output_refs)
+
+    results_path = case_with_results.load(fetch=True)
+
+    assert fetched is True
+    assert (results_path / "result.csv").read_text() == "1,2,3\n"


### PR DESCRIPTION
Commit 0967f17 changed Case.load() from updating the output repository to updating the project repository before looking for matching cached results. That fixed the update target only if loading is expected to sync repositories first, but it made a load operation mutate the study repository. In practice, Case.load() can now fetch, rebase, and hard-reset the project checkout before provenance matching happens.

This PR makes Case.load() read from local state by default. Loading results no longer updates the project repository, fetches output refs, or moves either checkout unless explicitly requested.

For callers that want to discover newly pushed output results before matching, Case.load(fetch=True) fetches the output repository refs first. This keeps the useful part of the old behavior, finding newly available output results, without pulling, rebasing, or resetting the project repository.

The tests cover that default Case.load() does not call project_repo.update(), does not fetch output refs by default, and leaves both repositories in the same Git state while still loading cached result files. They also cover that fetch=True performs the explicit output fetch path.

This changes an unintended side effect of Case.load(). Code that relied on loading to update the project repository should call project_repo.update() explicitly before loading.